### PR TITLE
Update REGEX for extracting track number to allow for multiple digits

### DIFF
--- a/radarr_import_subs.sh
+++ b/radarr_import_subs.sh
@@ -126,7 +126,7 @@ for rel_sub_dir in "${SUB_DIRS[@]}"; do
       while read -r -d '' sub_file; do
         dlog "Current subtitle: ${sub_file}"
         sub_ext="${sub_file##*.}"
-        if [[ "$sub_file" =~ ([0-9]) ]]; then
+        if [[ "$sub_file" =~ ([0-9]+) ]]; then
           # sub filename contains a track number
           sub_track_num="${BASH_REMATCH[1]}"
           # if there's only one sub file but it has a funny track number, just assume it's a normal sub (track 2)


### PR DESCRIPTION
Added + quantifier to REGEX for extracting track number to match any number of consecutive digits as opposed to a single digit